### PR TITLE
Log interaction before notifying subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2023-08-25
+
+### Fixed
+
+- Subscribers are now notified of changed attribution after logging the new interaction.  
+This way the subscribers have access to the full interaction log, including the interaction that just changed attribution.
+
 ## [0.4.0] - 2023-08-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeroen.bakker/just-attribute",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Realtime privacy-conscious marketing attribution for the web",
   "author": "Jeroen Bakker",
   "license": "MIT",

--- a/src/InteractionLogger.ts
+++ b/src/InteractionLogger.ts
@@ -115,10 +115,10 @@ export default class InteractionLogger {
         }
 
         if (this.hasAttributionChanged(interaction, lastInteractionTimestamp)) {
+            this.logInteraction(interaction);
+
             // Notify all subscribers that the attribution has changed and pass along the latest attribution
             this.attributionChangeCallbacks.forEach((callback) => callback(interaction));
-
-            this.logInteraction(interaction);
         }
     }
 

--- a/tests/InteractionLogger.test.ts
+++ b/tests/InteractionLogger.test.ts
@@ -131,6 +131,18 @@ test('it calls callback on changed attribution', async () => {
     expect(callback).toHaveBeenCalledTimes(2);
 });
 
+// By logging the interaction first, any subscribers can use the interaction log including the new interaction
+test('it logs interaction before notifying subscribers', () => {
+    const logger = new InteractionLogger();
+
+    const assertLogHasOneEntry = () => {
+        expect(logger.interactionLog().length).toBe(1);
+    };
+
+    logger.onAttributionChange(assertLogHasOneEntry);
+    logger.pageview(new URL('https://example.com/'), false);
+});
+
 test('it clears the log', async () => {
     const logger = new InteractionLogger();
     logger.pageview(new URL('https://example.com/'), false);


### PR DESCRIPTION
This way subscribers can get the full interaction log, including the interaction that just changed attribution.