### PR TITLE
Actually clear the log instead of setting null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2023-08-25
+
+### Fixed
+
+- Clear log no longer sets null but it actually removes the storage item.  
+Because the localStorage stores strings, and "null" is a string and valid JSON it was passing all checks 
+and it was being returned instead of an empty array.
+
 ## [0.4.1] - 2023-08-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeroen.bakker/just-attribute",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Realtime privacy-conscious marketing attribution for the web",
   "author": "Jeroen Bakker",
   "license": "MIT",

--- a/src/InteractionLogger.ts
+++ b/src/InteractionLogger.ts
@@ -196,7 +196,7 @@ export default class InteractionLogger {
      * This could be used after a user has converted and the attribution has been determined.
      */
     public clearLog(): void {
-        this.settings.storage.setItem(this.settings.logStorageKey, null);
+        this.settings.storage.removeItem(this.settings.logStorageKey);
     }
 
     public lastInteraction(): Interaction|null {

--- a/tests/fixtures/MemoryStorage.ts
+++ b/tests/fixtures/MemoryStorage.ts
@@ -27,5 +27,14 @@ export default class MemoryStorage implements Storage {
     }
 
     public removeItem(key: string): void {
+        delete this.store[key];
+    }
+
+    /**
+     * custom method to make it easier to test whether a key exists
+     * since when getItem() returns null, you can't tell whether it didn't exist or it actually contained null
+     */
+    public hasItem(key: string): boolean {
+        return this.store.hasOwnProperty(key);
     }
 }


### PR DESCRIPTION
Because the localStorage stores strings, and "null" is a string and valid JSON it was passing all checks and it was being returned instead of an empty array.