### PR TITLE
Check the last interaction timestamp after parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2023-08-27
+
+### Changed
+
+- Too large, small or otherwise invalid last interaction timestamps are explicitly handled.
+
 ## [0.4.3] - 2023-08-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeroen.bakker/just-attribute",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Realtime privacy-conscious marketing attribution for the web",
   "author": "Jeroen Bakker",
   "license": "MIT",

--- a/src/InteractionLogger.ts
+++ b/src/InteractionLogger.ts
@@ -43,7 +43,6 @@ export default class InteractionLogger {
         utm_term: 'term',
     };
 
-    private interactionLogCache: Interaction[] | null = null;
     private interactionMiddlewares: InteractionMiddleware[] = [];
     private attributionChangeCallbacks: Array<(Interaction) => any> = [];
 
@@ -180,22 +179,16 @@ export default class InteractionLogger {
     }
 
     public interactionLog(): Interaction[] {
-        this.interactionLogCache ??= deserializeInteractionLog.call(this);
+        const jsonLog = this.settings.storage.getItem(this.settings.logStorageKey);
 
-        return this.interactionLogCache;
+        if (!jsonLog) {
+            return [];
+        }
 
-        function deserializeInteractionLog() {
-            const jsonLog = this.settings.storage.getItem(this.settings.logStorageKey);
-
-            if (!jsonLog) {
-                return [];
-            }
-
-            try {
-                return JSON.parse(jsonLog) as Interaction[];
-            } catch {
-                return [];
-            }
+        try {
+            return JSON.parse(jsonLog) as Interaction[];
+        } catch {
+            return [];
         }
     }
 
@@ -204,7 +197,6 @@ export default class InteractionLogger {
      * This could be used after a user has converted and the attribution has been determined.
      */
     public clearLog(): void {
-        this.interactionLogCache = null;
         this.settings.storage.removeItem(this.settings.logStorageKey);
     }
 
@@ -300,7 +292,6 @@ export default class InteractionLogger {
             log = log.slice(-this.settings.logLimit);
         }
 
-        this.interactionLogCache = log;
         this.settings.storage.setItem(this.settings.logStorageKey, JSON.stringify(log));
     }
 }


### PR DESCRIPTION
This adds explicit handling of invalid numbers, whether they're too large, too small or otherwise invalid